### PR TITLE
可以在扩展的ServiceProvider内，use Slowlyo\OwlDict\Extend\CanImportDict; 然后在成员属性 定义dict变量 实现自动化安装字典。类似于menu的使用方式。

### DIFF
--- a/database/migrations/2023_02_09_105918_create_admin_dict_table.php
+++ b/database/migrations/2023_02_09_105918_create_admin_dict_table.php
@@ -16,6 +16,7 @@ return new class extends Migration {
             $table->tinyInteger('enabled')->default(1)->comment('是否启用')->index();
             $table->integer('sort')->default(0)->comment('排序')->index();
             $table->text('value')->comment('名称');
+
             $table->timestamps();
             $table->softDeletes();
         });

--- a/database/migrations/2023_02_09_105918_create_admin_dict_table.php
+++ b/database/migrations/2023_02_09_105918_create_admin_dict_table.php
@@ -16,7 +16,7 @@ return new class extends Migration {
             $table->tinyInteger('enabled')->default(1)->comment('是否启用')->index();
             $table->integer('sort')->default(0)->comment('排序')->index();
             $table->text('value')->comment('名称');
-
+            $table->string('extension')->nullable()->comment('扩展');
             $table->timestamps();
             $table->softDeletes();
         });

--- a/database/migrations/2023_02_09_105918_create_admin_dict_table.php
+++ b/database/migrations/2023_02_09_105918_create_admin_dict_table.php
@@ -16,7 +16,6 @@ return new class extends Migration {
             $table->tinyInteger('enabled')->default(1)->comment('是否启用')->index();
             $table->integer('sort')->default(0)->comment('排序')->index();
             $table->text('value')->comment('名称');
-            $table->string('extension')->nullable()->comment('扩展');
             $table->timestamps();
             $table->softDeletes();
         });

--- a/database/migrations/2024_06_28_164445_create_admin_dict_table.php
+++ b/database/migrations/2024_06_28_164445_create_admin_dict_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('admin_dict', function (Blueprint $table) {
+            $table->string('extension')->nullable()->comment('扩展');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('admin_dict', function (Blueprint $table) {
+            $table->removeColumn('extension');
+        });
+    }
+};

--- a/src/Extend/CanImportDict.php
+++ b/src/Extend/CanImportDict.php
@@ -12,7 +12,6 @@ use Slowlyo\OwlDict\Models\AdminDict;
  */
 trait CanImportDict
 {
-    protected $dict = [];
 
     protected array $dictValidationRules = [
         'parent'   => 'nullable',

--- a/src/Extend/CanImportDict.php
+++ b/src/Extend/CanImportDict.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Slowlyo\OwlDict\Extend;
+
+use Illuminate\Support\Arr;
+use Slowlyo\OwlAdmin\Admin;
+use Illuminate\Support\Facades\Validator;
+use Slowlyo\OwlDict\Models\AdminDict;
+
+/**
+ * @property \Symfony\Component\Console\Output\OutputInterface $output
+ */
+trait CanImportDict
+{
+    protected $dict = [];
+
+    protected array $dictValidationRules = [
+        'parent'   => 'nullable',
+        'key'    => 'required',
+        'value'    => 'required',
+    ];
+
+    /**
+     * 获取字典节点.
+     *
+     * @return array
+     */
+    protected function dict()
+    {
+        return $this->dict;
+    }
+
+    /**
+     * 添加字典.
+     *
+     * @param array $dict
+     *
+     * @throws \Exception
+     */
+    protected function addDict(array $dict = [])
+    {
+        $dict = $dict ?: $this->dict();
+
+        if (!Arr::isAssoc($dict)) {
+            foreach ($dict as $v) {
+                $this->addDict($v);
+            }
+
+            return;
+        }
+
+        if (!$this->validateDict($dict)) {
+            return;
+        }
+
+        AdminDict::create([
+            'parent_id' => $this->getParentDictId($dict['parent'] ?? 0),
+            'key'     => $dict['key'],
+            'value'     => $dict['value'],
+            'extension' => $this->getName(),
+        ]);
+    }
+
+    /**
+     * 刷新菜单.
+     *
+     * @throws \Exception
+     */
+    protected function refreshDict()
+    {
+        $this->flushDict();
+
+        $this->addDict();
+    }
+
+    /**
+     * 根据名称获取菜单ID.
+     *
+     * @param int|string $parent
+     *
+     * @return int
+     */
+    protected function getParentDictId($parent)
+    {
+
+        return AdminDict::query()
+            ->where('key', $parent)
+            ->where('extension', $this->getName())
+            ->value('id') ?: 0;
+    }
+
+    /**
+     * 删除字典.
+     */
+    protected function flushDict()
+    {
+        AdminDict::query()
+            ->where('extension', $this->getName())
+            ->delete();
+    }
+
+    /**
+     * 验证菜单字段格式是否正确.
+     *
+     * @param array $dict
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public function validateDict(array $dict)
+    {
+        /** @var \Illuminate\Validation\Validator $validator */
+        $validator = Validator::make($dict, $this->dictValidationRules);
+
+        if ($validator->passes()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Extend/CanImportDict.php
+++ b/src/Extend/CanImportDict.php
@@ -52,11 +52,13 @@ trait CanImportDict
             return;
         }
 
-        AdminDict::create([
+        AdminDict::query()->insert([
             'parent_id' => $this->getParentDictId($dict['parent'] ?? 0),
             'key'     => $dict['key'],
             'value'     => $dict['value'],
             'extension' => $this->getName(),
+            'created_at'=>date('Y-m-d H:i:s'),
+            'updated_at'=>date('Y-m-d H:i:s'),
         ]);
     }
 


### PR DESCRIPTION
可以在扩展的ServiceProvider内，use Slowlyo\OwlDict\Extend\CanImportDict; 然后在成员属性 定义dict变量 实现自动化安装字典。类似于menu的使用方式。

同时 CanImportDict trait 、CanImportMenu trait 不能预定义 $menu 或者 $dict 否则会出现 xxx\xxx\xxxServiceProvider and Slowlyo\OwlDict\Extend\CanImportDict define the same property ($dict) in the composition of xxx\xxx\xxxServiceProvider. However, the definition differs and is considered incompatible. Class was composed


文档已完善更新